### PR TITLE
RF: use os.makedirs, don't catch errors and hard exit.

### DIFF
--- a/fetch_shapefiles.py
+++ b/fetch_shapefiles.py
@@ -149,7 +149,7 @@ def main(args=None):
     # make sure we have the expected directories
     for path in [DOWNLOAD_DIR, EXTRACT_DIR]:
         if not isdir(path):
-            os.mkdir(path)
+            os.makedirs(path)
 
     state = options.state if options.state else None
     geo_type = options.geo_type if options.geo_type else None
@@ -167,11 +167,4 @@ def main(args=None):
 
 
 if __name__ == '__main__':
-    try:
-        main()
-    except Exception, e:
-        sys.stderr.write('\n')
-        traceback.print_exc(file=sys.stderr)
-        sys.stderr.write('\n')
-        sys.exit(1)
-
+    main()

--- a/parse_shapefiles.py
+++ b/parse_shapefiles.py
@@ -221,8 +221,8 @@ def main(args=None):
     # make sure we have the expected directories
     for path in [CSV_DIR,]:
         if not isdir(path):
-            os.mkdir(path)
-    
+            os.makedirs(path)
+
     state = options.state if options.state else None
     geo_type = options.geo_type if options.geo_type else None
 
@@ -239,11 +239,4 @@ def main(args=None):
 
 
 if __name__ == '__main__':
-    try:
-        main()
-    except Exception, e:
-        sys.stderr.write('\n')
-        traceback.print_exc(file=sys.stderr)
-        sys.stderr.write('\n')
-        sys.exit(1)
-
+    main()


### PR DESCRIPTION
Two small changes:
- `os.makedirs` handles the case where the missing path has multiple levels of directories not created. It's strictly better than `os.mkdir`
- Don't explicitly catch errors and exit; Python prints error information as-is anyway. Instead, just let the errors remain uncaught, so users / developers can debug any issues.
